### PR TITLE
feat : 프로필수정(이름변경), 비밀번호변경 구현

### DIFF
--- a/alphabot-back/app/routers/user.py
+++ b/alphabot-back/app/routers/user.py
@@ -2,10 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.models.models import User as ORMUser
-from app.schemas.user import User, UserCreate
+from app.schemas.user import User, UserCreate, UserUpdate, PasswordChange
 from app.core import dependencies
 from app.crud import crud_user
 from app.db.session import get_db
+from app.core.security import verify_password
 
 # prefix="/api"는 main.py에서 설정함. 여기서는 생략.
 router = APIRouter()
@@ -42,3 +43,44 @@ def read_users_me(
     - 현재 로그인된 사용자의 정보를 반환합니다. (토큰 필요)
     """
     return current_user
+
+
+
+@router.patch("/users/me", response_model=User)
+def update_user_me(
+    *,
+    db: Session = Depends(get_db),
+    user_in: UserUpdate,
+    current_user: ORMUser = Depends(dependencies.get_current_user),
+):
+    """
+    ## 내 프로필 수정
+    - 사용자 이름(닉네임)을 변경합니다.
+    """
+    user = crud_user.update_user(db, db_user=current_user, obj_in=user_in)
+    return user
+
+@router.put("/users/me/password", status_code=status.HTTP_200_OK)
+def change_password(
+    *,
+    db: Session = Depends(get_db),
+    password_in: PasswordChange,
+    current_user: ORMUser = Depends(dependencies.get_current_user),
+):
+    """
+    ## 비밀번호 변경
+    - 현재 비밀번호를 확인하고 새 비밀번호로 변경합니다.
+    """
+    # 1. 현재 비밀번호가 맞는지 확인
+    if not verify_password(password_in.current_password, current_user.hashed_pw):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="현재 비밀번호가 일치하지 않습니다.",
+        )
+    
+    # 2. 새 비밀번호와 확인 비밀번호가 일치하는지는 Pydantic Schema(PasswordChange)에서 이미 검증됨
+    
+    # 3. 비밀번호 변경 실행
+    crud_user.update_password(db, db_user=current_user, new_password=password_in.new_password)
+    
+    return {"message": "비밀번호가 성공적으로 변경되었습니다."}

--- a/alphabot-front/src/api/userClient.ts
+++ b/alphabot-front/src/api/userClient.ts
@@ -1,0 +1,38 @@
+import { apiClient } from '@/lib/apiClient';
+
+// 사용자 정보 타입
+export interface User {
+  user_id: number;
+  login_id: string;
+  username: string;
+}
+
+// 프로필 수정 요청 데이터 타입
+export interface UserUpdatePayload {
+  username: string;
+}
+
+// 비밀번호 변경 요청 데이터 타입
+export interface PasswordChangePayload {
+  current_password: string;
+  new_password: string;
+  new_password_confirm: string;
+}
+
+// 1. 내 정보 가져오기
+export const getMe = async (): Promise<User> => {
+  const response = await apiClient.get<User>('/users/me');
+  return response.data;
+};
+
+// 2. 프로필 수정하기
+export const updateProfile = async (payload: UserUpdatePayload): Promise<User> => {
+  const response = await apiClient.patch<User>('/users/me', payload);
+  return response.data;
+};
+
+// 3. 비밀번호 변경하기
+export const changePassword = async (payload: PasswordChangePayload): Promise<{ message: string }> => {
+  const response = await apiClient.put<{ message: string }>('/users/me/password', payload);
+  return response.data;
+};


### PR DESCRIPTION
백
CRUD 로직 추가 app/crud/crud_user.py
update_user: 사용자 정보를 수정하는 함수 추가
update_password: 비밀번호를 해싱하여 변경하는 함수 추가
API 엔드포인트 추가 app/routers/user.py
PATCH /api/users/me: 프로필 수정 API
PUT /api/users/me/password: 현재 비밀번호 검증 로직 및 비밀번호 변경 API
Schema 추가 app/schemas/user.py
UserUpdate, PasswordChange 스키마 적용

프론트
API Client 생성 src/api/userClient.ts
사용자 정보 조회getMe, 프로필 수정updateProfile, 비밀번호 변경changePassword 함수 구현
마이페이지 로직 수정 src/pages/MyPage.tsx
하드코딩된 Mock 데이터를 제거하고 API 연동
페이지 진입 시 사용자 정보getMe 호출
프로필 수정 및 비밀번호 변경 폼 핸들링 및 유효성 검사 로직 추가

테스트
회원가입 > 로그인 > 이름수정, 비밀번호 수정 > 로그아웃 >
case1 변경 전 pw로 로그인시도 > 로그인실패
case2 변경 후 pw로 로그인시도 > 로그인성공